### PR TITLE
Replace single quotes with double to not speak underscores

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,16 +8,10 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
 
     // we want to run npm
     "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
 
     // we run the custom script "compile" as defined in package.json
     "args": ["run", "compile", "--loglevel", "silent"],
@@ -26,5 +20,24 @@
     "isWatching": true,
 
     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "problemMatcher": "$tsc-watch",
+    "tasks": [
+        {
+            "label": "npm",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "compile",
+                "--loglevel",
+                "silent"
+            ],
+            "isBackground": true,
+            "problemMatcher": "$tsc-watch",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        }
+    ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,65 @@
 {
   "name": "speech",
-  "version": "0.0.3",
-  "lockfileVersion": 1,
+  "version": "0.0.4",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "speech",
+      "version": "0.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "say": "^0.15.0"
+      },
+      "devDependencies": {
+        "@types/vscode": "^1.5.0",
+        "typescript": "^4.0.0"
+      },
+      "engines": {
+        "vscode": "^1.5.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
+      "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
+      "dev": true
+    },
+    "node_modules/one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
+    "node_modules/say": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/say/-/say-0.15.0.tgz",
+      "integrity": "sha512-X/vJ/ETDUnU0WZVJ1HA6AHzJJzT0PvFuZyThJ76wkqwsgcgvqJVH3tf+EqHdDBgANdYUEEmqzYo6I31cvT08pQ==",
+      "dependencies": {
+        "one-time": "0.0.4"
+      },
+      "engines": {
+        "node": ">=6.9"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@types/vscode": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-      "integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
+      "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
       "dev": true
     },
     "one-time": {
@@ -24,9 +76,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "speech",
   "displayName": "VSCode Speech",
   "description": "Text to speech",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "bierner",
   "license": "MIT",
-  "extensionKind": "ui",
+  "extensionKind": ["ui"],
   "keywords": [
     "speech",
     "say",
@@ -37,10 +37,7 @@
       "title": "Speech configuration",
       "properties": {
         "speech.voice": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "default": null,
           "description": "Name of voice used to speak text."
         },
@@ -48,6 +45,17 @@
           "type": "number",
           "default": 1,
           "description": "Speech rate speed multiplier."
+        },
+        "speech.substitutions": {
+          "type": "object",
+          "patternProperties": {
+            "": { "type": "string" }
+          },
+          "additionalProperties": false,
+          "default": {
+            "_": " "
+          },
+          "description": "A dictionary of characters to replace with other characters before speaking. This can help with characters that text-to-speech reads in an unexpected way."
         }
       }
     },
@@ -92,8 +100,8 @@
     "watch": "tsc -watch -p ./"
   },
   "devDependencies": {
-    "typescript": "^3.4.0",
-    "@types/vscode": "^1.33.0"
+    "typescript": "^4.0.0",
+    "@types/vscode": "^1.5.0"
   },
   "dependencies": {
     "say": "^0.15.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,14 @@
 import * as vscode from 'vscode';
 import * as say from 'say';
 
-const getVoice = (): string| undefined =>
+const getVoice = (): string | undefined =>
     vscode.workspace.getConfiguration('speech').get<string>('voice');
 
 const getSpeed = (): number | undefined =>
     vscode.workspace.getConfiguration('speech').get<number>('speed');
+
+const getSubstitutions = (): { [key: string]: string } => 
+    vscode.workspace.getConfiguration('speech').get<{ [key: string]: string }>('substitutions') || {};
 
 
 const stopSpeaking = () => {
@@ -14,7 +17,9 @@ const stopSpeaking = () => {
 
 const cleanText = (text: string): string => {
     text = text.trim();
-    text = text.replace(/'/g, '"');
+    for (let [pattern, replacement] of Object.entries(getSubstitutions())) {
+        text = text.replaceAll(pattern, replacement);
+    }
     return text;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,14 @@ const stopSpeaking = () => {
     say.stop();
 }
 
-const speakText = (text: string) => {
+const cleanText = (text: string): string => {
     text = text.trim();
+    text = text.replace(/'/g, '"');
+    return text;
+}
+
+const speakText = (text: string) => {
+    text = cleanText(text);
     if (text.length > 0) {
         say.speak(text, getVoice(), getSpeed());
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "outDir": "out",
         "sourceMap": true,
         "rootDir": "src",
-        "strict": true
+        "strict": true,
+        "lib": ["es2021"]
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Thank you for developing this extension! I use it for work to help me stay focused and read code.

This PR is to resolve a minor annoyance when using text-to-speech for code: it enunciating underscores.

Say I have `d['my_dict_key']` in my code. This will be read as "d my underscore dict underscore key". This is hard to understand. I've found that replacing the single quotes with double quotes makes the TTS read it as "d my dict key", much easier to parse aurally.

I propose this PR because some companies' style guide may force users to use single quotes. As for using underscores in names, PEP 8 suggests using underscores rather than camel case (which TTS does read properly already). I'm getting around to making this improvement suggestion as part of Hacktoberfest, could you please add the tag "hacktoberfest-accepted" if you agree?

Thank you for you time in reviewing this, please let me know if you have any feedback.